### PR TITLE
i18nによる日本語対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,8 @@ gem "bootsnap", require: false
 
 gem 'sorcery'
 
+gem 'rails-i18n', '~> 7.0.0'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,6 +213,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails-i18n (7.0.9)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.1.3.4)
       actionpack (= 7.1.3.4)
       activesupport (= 7.1.3.4)
@@ -295,6 +298,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.4)
+  rails-i18n (~> 7.0.0)
   selenium-webdriver
   sorcery
   sprockets-rails

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,14 +1,14 @@
 <header class="flex items-center justify-between h-16 px-4 shadow-md">
   <h1 class="">
-    <%= link_to 'こぎフォト', root_path, class: '' %>
+    <%= link_to t('header.title'), root_path, class: '' %>
   </h1>
   <nav class="hidden md:block">
     <ul class="flex items-center gap-3">
       <li class="">
-        <%= link_to '新規登録', new_user_path, class: '' %>
+        <%= link_to t('header.to_register_page'), new_user_path, class: '' %>
       </li>
       <li class="">
-        <%= link_to 'ログイン', login_path, class: '' %>
+        <%= link_to t('header.login'), login_path, class: '' %>
       </li>
     </ul>
   </nav>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,14 +1,14 @@
 <header class="flex items-center justify-between h-16 px-4 shadow-md">
   <h1 class="">
-    <%= link_to 'こぎフォト', root_path, class: '' %>
+    <%= link_to t('header.title'), root_path, class: '' %>
   </h1>
   <nav class="hidden md:block">
     <ul class="flex items-center gap-3">
       <li class="">
-        <%= link_to '掲示板一覧', '#', class: '' %>
+        <%= link_to t('header.board_index'), '#', class: '' %>
       </li>
       <li class="">
-        <%= link_to 'ログアウト', logout_path, class: '', data: { turbo_method: :delete } %>
+        <%= link_to t('header.logout'), logout_path, class: '', data: { turbo_method: :delete } %>
       </li>
     </ul>
   </nav>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,5 +1,5 @@
 <div class="mx-auto my-10 max-w-3xl px-5 md:my-20">
-  <h1 class="text-3xl text-center ">ログイン</h1>
+  <h1 class="text-3xl text-center "><%= t('.title') %></h1>
   <%= form_with url: login_path, class: 'grid grid-cols-1 gap-5 mt-10' do |f| %>
     <div class="grid grid-cols-1 gap-3">
       <%= f.label :email, class: 'font-medium' %>
@@ -10,7 +10,7 @@
       <%= f.password_field :password, class: 'border rounded text-base p-2' %>
     </div>
     <div class="text-center">
-      <%= f.submit 'ログイン', class: 'inline-block border rounded px-4 py-2' %>
+      <%= f.submit t('.login'), class: 'inline-block border rounded px-4 py-2' %>
     </div>
   <% end %>
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,5 +1,5 @@
 <div class="mx-auto my-10 max-w-3xl px-5 md:my-20">
-  <h1 class="text-3xl text-center ">ユーザー登録</h1>
+  <h1 class="text-3xl text-center "><%= t('.title') %></h1>
   <%= form_with model: @user, class: 'grid grid-cols-1 gap-5 mt-10' do |f| %>
     <div class="grid grid-cols-1 gap-3">
       <%= f.label :name, class: 'font-medium' %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,7 @@ module Myapp
       g.helper false
       g.test_framework nil
     end
+
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/locales/acriverecord/ja.yml
+++ b/config/locales/acriverecord/ja.yml
@@ -1,0 +1,10 @@
+ja:
+  activerecord:
+    models:
+      user: ユーザー
+    attributes:
+      user:
+        name: 名前
+        email: メールアドレス
+        password: パスワード
+        password_confirmation: パスワード確認

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,0 +1,27 @@
+ja:
+  helpers:
+    submit:
+      create: 登録
+      submit: 保存
+      update: 更新
+    label:
+      email: メールアドレス
+      password: パスワード
+  users:
+    new:
+      title: ユーザー登録
+  user_sessions:
+    new:
+      title: ログイン
+      login: ログイン
+      to_register_page: 登録ページへ
+      password_forget: パスワードをお忘れの方はこちら
+  header:
+    title: こぎフォト
+    login: ログイン
+    logout: ログアウト
+    to_register_page: 新規登録
+    board: 掲示板
+    board_index: 掲示板一覧
+    board_create: 掲示板作成
+    bookmark_index: ブックマーク一覧


### PR DESCRIPTION
### やったこと
- gem rails-i18n(ver7.0.0)をインストール
- Railsのデフォルト言語を日本語に設定
- localesディレクトリに新しくja.ymlファイル作成
- ヘッダー、新規登録ページ、ログインページを日本語対応

### やらないこと
なし

### できるようになること（ユーザー目線）
なし

### できなくなること（ユーザー目線）
なし

### その他（実装上の懸念点や注意点など）
なし